### PR TITLE
Add determinant operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Doing calculations in F8:
 - Solving **homogeneous equation systems**
 - Converting a matrix to 
 **[reduced row echelon form](https://en.wikipedia.org/wiki/Row_echelon_form#Reduced_row_echelon_form)**
+- Calculating the **determinant** of a matrix
 
 Details and instructions for all described functions can be found on the 
 [website of this project](https://matrixer.davidaugustat.com/).

--- a/source/html/templates/de/instructions-de.html
+++ b/source/html/templates/de/instructions-de.html
@@ -300,8 +300,8 @@
         <li>
             <b>Die Determinante einer Matrix berechnen:</b>
             <p>
-                Z.B. in R: <span class="input-example">determinant({1,2,3;4,5,7;8,9,10})</span>
-                \(= determinant(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
+                Z.B. in R: <span class="input-example">det({1,2,3;4,5,7;8,9,10})</span>
+                \(= det(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
             </p>
         </li>
     </ul>

--- a/source/html/templates/de/instructions-de.html
+++ b/source/html/templates/de/instructions-de.html
@@ -297,6 +297,13 @@
                 Z.B. in R: <span class="input-example">additiveinverse(4)</span> \(=additiveinverse(4) = -4\)
             </p>
         </li>
+        <li>
+            <b>Die Determinante einer Matrix berechnen:</b>
+            <p>
+                Z.B. in R: <span class="input-example">determinant({1,2,3;4,5,7;8,9,10})</span>
+                \(= determinant(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
+            </p>
+        </li>
     </ul>
     <h4>Was kann Matrixer nicht?</h4>
     <ul>

--- a/source/html/templates/en/instructions-en.html
+++ b/source/html/templates/en/instructions-en.html
@@ -295,6 +295,13 @@
                 E.g. in R: <span class="input-example">additiveinverse(4)</span> \(=additiveinverse(4) = -4\)
             </p>
         </li>
+        <li>
+            <b>Calculate the determinant of a matrix:</b>
+            <p>
+                E.g. in R: <span class="input-example">determinant({1,2,3;4,5,7;8,9,10})</span>
+                \(= determinant(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
+            </p>
+        </li>
     </ul>
     <h4>What can't Matrixer do?</h4>
     <ul>

--- a/source/html/templates/en/instructions-en.html
+++ b/source/html/templates/en/instructions-en.html
@@ -298,8 +298,8 @@
         <li>
             <b>Calculate the determinant of a matrix:</b>
             <p>
-                E.g. in R: <span class="input-example">determinant({1,2,3;4,5,7;8,9,10})</span>
-                \(= determinant(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
+                E.g. in R: <span class="input-example">det({1,2,3;4,5,7;8,9,10})</span>
+                \(= det(\begin{pmatrix}1&2&3\\4&5&7\\8&9&10\end{pmatrix}) = 7\)
             </p>
         </li>
     </ul>

--- a/source/mathEngine/Constants.js
+++ b/source/mathEngine/Constants.js
@@ -16,7 +16,7 @@ export const Operators = {
     MULTIPLICATIVE_INVERSE: 'multinverse',
     ADDITIVE_INVERSE: 'additiveinverse',
     SOLVE_HOMOGENEOUS: 'solvehom',
-    DETERMINANT: 'determinant'
+    DETERMINANT: 'det'
 };
 
 export const MathElementType = {

--- a/source/mathEngine/Constants.js
+++ b/source/mathEngine/Constants.js
@@ -15,7 +15,8 @@ export const Operators = {
     TRANSPOSE: 'transpose',
     MULTIPLICATIVE_INVERSE: 'multinverse',
     ADDITIVE_INVERSE: 'additiveinverse',
-    SOLVE_HOMOGENEOUS: 'solvehom'
+    SOLVE_HOMOGENEOUS: 'solvehom',
+    DETERMINANT: 'determinant'
 };
 
 export const MathElementType = {
@@ -27,16 +28,16 @@ export const MathElementType = {
 export const Constants = {
     listOfAllOperators: [Operators.ADD, Operators.SUBTRACT, Operators.MULTIPLY, Operators.EXPONENTIATE,
         Operators.DIVIDE, Operators.ROW_REDUCE, Operators.TRANSPOSE, Operators.MULTIPLICATIVE_INVERSE,
-        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS],
+        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS, Operators.DETERMINANT],
 
     infixOperators: [Operators.ADD, Operators.SUBTRACT, Operators.MULTIPLY, Operators.DIVIDE, Operators.EXPONENTIATE],
 
     // bracket operators are function operators AND non-math-element operators
     bracketOperators: [Operators.ROW_REDUCE, Operators.TRANSPOSE, Operators.MULTIPLICATIVE_INVERSE,
-        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS, Operators.SOLVE_HOMOGENEOUS],
+        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS, Operators.SOLVE_HOMOGENEOUS, Operators.DETERMINANT],
 
     functionOperators: [Operators.ROW_REDUCE, Operators.TRANSPOSE, Operators.MULTIPLICATIVE_INVERSE,
-        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS],
+        Operators.ADDITIVE_INVERSE, Operators.SOLVE_HOMOGENEOUS, Operators.DETERMINANT],
 
     // Operators, that don't return a MathElement:
     nonMathElementOperators: [Operators.SOLVE_HOMOGENEOUS],

--- a/source/mathEngine/Exceptions.js
+++ b/source/mathEngine/Exceptions.js
@@ -211,8 +211,8 @@ export const Exceptions = {
     },
 
     DeterminantNotAMatrixException: {
-        englishMessage: "The determinant operator can only process matrices.",
-        germanMessage: "Der determinant-Operator kann nur Matrizen verarbeiten."
+        englishMessage: "The determinant operator (det) can only process matrices.",
+        germanMessage: "Der Determinanten-Operator (det) kann nur Matrizen verarbeiten."
     },
 
     DeterminantNotASquareMatrixException: {

--- a/source/mathEngine/Exceptions.js
+++ b/source/mathEngine/Exceptions.js
@@ -210,6 +210,16 @@ export const Exceptions = {
         germanMessage: "Die Matrix besitzt keine inverse Matrix."
     },
 
+    DeterminantNotAMatrixException: {
+        englishMessage: "The determinant operator can only process matrices.",
+        germanMessage: "Der determinant-Operator kann nur Matrizen verarbeiten."
+    },
+
+    DeterminantNotASquareMatrixException: {
+        englishMessage: "The matrix does not have a determinant since it's not a square matrix.",
+        germanMessage: "Die Matrix hat keine Determinante, da sie keine quadratische Matrix ist."
+    },
+
     EmptyInputException: {
         englishMessage: "No input has been entered. Please enter an expression in the text field.",
         germanMessage: "Es wurde nichts eingegeben. Bitte gib einen mathematischen Ausdruck in das Textfeld ein."

--- a/source/mathEngine/stringInterpretation/ExpressionNode.js
+++ b/source/mathEngine/stringInterpretation/ExpressionNode.js
@@ -100,6 +100,8 @@ export default class ExpressionNode {
                     return this._getMultiplicativeInverse();
                 case Operators.ADDITIVE_INVERSE:
                     return this._getAdditiveInverse();
+                case Operators.DETERMINANT:
+                    return this._getDeterminant();
                 default:
                     throw Exceptions.InvalidOperatorException;
             }
@@ -167,4 +169,17 @@ export default class ExpressionNode {
         throw Exceptions.AdditiveInverseNoNumberException;
     }
 
+    /**
+     * Internal method to check if the result of left node is a matrix. If it is, the determinant of the matrix
+     * will be returned. Otherwise an exception will be thrown, because only matrices have a determinant.
+     *
+     * @returns {GeneralNumber}
+     * */
+    _getDeterminant(){
+        const innerValue = this.leftNode.calculate();
+        if(innerValue instanceof Matrix){
+            return innerValue.getDeterminant();
+        }
+        throw Exceptions.DeterminantNotAMatrixException;
+    }
 }


### PR DESCRIPTION
I've been using your tool for some time but yesterday I wanted to calculate the determinant of a matrix and saw that that feature was not included. So I coded it myself, I hope I did everything right and didn't forget anything, I don't often code in JavaScript.

The calculation I used is fairly easy:
1. Check if it's a square matrix.
2. Convert the matrix to a upper-triangular matrix:
  1. For each column `i`, if the value in `i,i` is 0, swap the row `i` with the first lower row with a non-zero element (if there is no such row, the determinant is zero).
  2. Eliminate the values in the lower rows in the current column by using matrix transformations.
4. Calculate the determinant by multiplying the diagonal elements and negating the result if there was an uneven number of row swaps.

If you don't want to have the feature to calculate determinants, that's fine as well. Just close this pr and I will self-host my instance with the feature.