### PR TITLE
Fix check if matrix is invertable.

### DIFF
--- a/source/mathEngine/math/Matrix.js
+++ b/source/mathEngine/math/Matrix.js
@@ -444,10 +444,8 @@ export default class Matrix extends MathElement{
             throw Exceptions.InvertNotInvertable;
         }
         let reducedOriginal = this.rowReduce();
-        for(let n = 0; n < this.rows; n++){
-            if(reducedOriginal.value[n][n].value != one.value){
-                throw Exceptions.InvertNotInvertable;
-            }
+        if (reducedOriginal._nonStepColumns.length != 0) {
+            throw Exceptions.InvertNotInvertable;
         }
 
         // For the given n x n matrix A row-reduce the new matrix (A|E) with E being the n-th identity matrix


### PR DESCRIPTION
While implementing the determinant feature in my other pr, I noticed that for some matrices the check if a matrix is invertable in the `multinverse` operator does not always work. That is due to floating point numbers.
E.g. the command `multinverse ( {1,2,3; 4,5,7; 8,9,10} )` in `R` says that the matrix is not invertable even though it is. If you debug the code you notice that the reduced matrix is not `{ 1, 0, 0; 0, 1, 0; 0, 0, 1 }` but rather `{ 1, 0, 0; 0, 0.999..., 0; 0, 0, 1 }` and the previous code therefore thought that the matrix wasn't invertable.

I changed it so that the code instead checks if any `nonStepColumns` were found, if no the matrix is invertable. To my knowledge of invertable matrices, this should always work.